### PR TITLE
Switch to millisecond resolution (fixes #2)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,13 @@
 2024-05-31  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version,Date): Roll micro version and date
+
 	* src/ulid/ulid_struct.h: Switch to fork by Chris Bove which uses
 	std::chrono internally thus providing millisecond resolutions
 	* src/ulid/ulid_uint128.h: Idem
 	* src/wrapper.cpp: Updated to use std::chrono instead of time_t
 
+	* README.md: Document updates
 
 2024-05-30  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2024-05-31  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/ulid/ulid_struct.h: Switch to fork by Chris Bove which uses
+	std::chrono internally thus providing millisecond resolutions
+	* src/ulid/ulid_uint128.h: Idem
+	* src/wrapper.cpp: Updated to use std::chrono instead of time_t
+
+
 2024-05-30  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version,Date): Roll micro version and date

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ulid
 Type: Package
 Title: Generate Universally Unique 'Lexicographically' 'Sortable' Identifiers
-Version: 0.3.1.1
+Version: 0.3.1.2
 Date: 2024-05-30
 Authors@R: c(
   person("Bob", "Rudis", role = "aut", comment = c(ORCID = "0000-0001-5670-2640")),

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![CRAN](https://www.r-pkg.org/badges/version/ulid)](https://cran.r-project.org/package=ulid)
 [![r-universe](https://eddelbuettel.r-universe.dev/badges/ulid)](https://eddelbuettel.r-universe.dev/ulid)
 [![Dependencies](https://tinyverse.netlify.app/badge/ulid)](https://cran.r-project.org/package=ulid)
+[![Downloads](https://cranlogs.r-pkg.org/badges/ulid?color=brightgreen)](https://www.r-pkg.org:443/pkg/ulid)
 [![Last Commit](https://img.shields.io/github/last-commit/eddelbuettel/ulid)](https://github.com/eddelbuettel/ulid)
 
 
@@ -133,14 +134,35 @@ unmarshal(ut)
 ## 1 2017-11-01 15:00:00 2THKSAX3F1SF30E7
 ```
 
-### Known Limitation
+### Extensions
 
 As per [issue #13](https://github.com/suyash/ulid/issues/13) on the upstream repo, time is actually
-encoded mostly as `time_t` leading to second rather than millisecond resolution.
+encoded mostly as `time_t` leading to second rather than millisecond resolution. Two patches by
+Chris Brove also collected in [his fork](https://github.com/ChrisBove/ulid) improve on this by using
+`std::chrono` objects internally.  We have extended the wrapper functions to support this:
+
+```r
+> library(ulid)
+> gen_ulid <- \(sleep) replicate(5, {Sys.sleep(sleep); generate()})
+> u <- gen_ulid(.1)
+> df <- unmarshal(u)
+> data.table::data.table(df)
+                        ts              rnd
+                    <POSc>           <char>
+1: 2024-05-30 16:38:28.588 CSQAJBPNX75R0G5A
+2: 2024-05-30 16:38:28.688 XZX0TREDHD6PC1YR
+3: 2024-05-30 16:38:28.789 0YK9GKZVTED27QMK
+4: 2024-05-30 16:38:28.890 SC3M3G6KGPH7S50S
+5: 2024-05-30 16:38:28.990 TSKCBWJ3TEKCPBY0
+>
+```
 
 ### Author
 
-[Suyash Verma](https://github.com/suyash) wrote the C++ header library [ulid](https://github.com/suyash/ulid).
+[Suyash Verma](https://github.com/suyash) wrote the C++ header library
+[ulid](https://github.com/suyash/ulid).
+
+[Chris Bove](https://github.com/ChrisBove) updated internals to permit sub-second resolution.
 
 [Bob Rudis](https://rud.is) created the R package, prepared versions 0.1.0 and 0.2.0, and released version 0.3.0 to CRAN.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Chris Brove also collected in [his fork](https://github.com/ChrisBove/ulid) impr
 [Suyash Verma](https://github.com/suyash) wrote the C++ header library
 [ulid](https://github.com/suyash/ulid).
 
-[Chris Bove](https://github.com/ChrisBove) updated internals to permit sub-second resolution.
+[Chris Bove](https://github.com/ChrisBove) updated internals to permit sub-second resolution in his
+[fork](https://github.com/ChrisBove/ulid).
 
 [Bob Rudis](https://rud.is) created the R package, prepared versions 0.1.0 and 0.2.0, and released version 0.3.0 to CRAN.
 

--- a/local/gh_issue_2.R
+++ b/local/gh_issue_2.R
@@ -8,3 +8,4 @@ u
 df <- unmarshal(u)
 format(df$ts, "%Y-%m-%d %H:%M:%OS3")
 diff(df$ts)
+data.table::data.table(df)

--- a/src/ulid/ulid_struct.h
+++ b/src/ulid/ulid_struct.h
@@ -16,255 +16,257 @@ namespace ulid {
  * ULID is a 16 byte Universally Unique Lexicographically Sortable Identifier
  * */
 struct ULID {
-  uint8_t data[16];
+	uint8_t data[16];
 
-  ULID() {
-    // for (int i = 0 ; i < 16 ; i++) {
-    // 	data[i] = 0;
-    // }
+	ULID() {
+		// for (int i = 0 ; i < 16 ; i++) {
+		// 	data[i] = 0;
+		// }
 
-    // unrolled loop
-    data[0] = 0;
-    data[1] = 0;
-    data[2] = 0;
-    data[3] = 0;
-    data[4] = 0;
-    data[5] = 0;
-    data[6] = 0;
-    data[7] = 0;
-    data[8] = 0;
-    data[9] = 0;
-    data[10] = 0;
-    data[11] = 0;
-    data[12] = 0;
-    data[13] = 0;
-    data[14] = 0;
-    data[15] = 0;
-  }
+		// unrolled loop
+		data[0] = 0;
+		data[1] = 0;
+		data[2] = 0;
+		data[3] = 0;
+		data[4] = 0;
+		data[5] = 0;
+		data[6] = 0;
+		data[7] = 0;
+		data[8] = 0;
+		data[9] = 0;
+		data[10] = 0;
+		data[11] = 0;
+		data[12] = 0;
+		data[13] = 0;
+		data[14] = 0;
+		data[15] = 0;
+	}
 
-  ULID(uint64_t val) {
-    // for (int i = 0 ; i < 16 ; i++) {
-    // 	data[15 - i] = static_cast<uint8_t>(val);
-    // 	val >>= 8;
-    // }
+	ULID(uint64_t val) {
+		// for (int i = 0 ; i < 16 ; i++) {
+		// 	data[15 - i] = static_cast<uint8_t>(val);
+		// 	val >>= 8;
+		// }
 
-    // unrolled loop
-    data[15] = static_cast<uint8_t>(val);
+		// unrolled loop
+		data[15] = static_cast<uint8_t>(val);
 
-    val >>= 8;
-    data[14] = static_cast<uint8_t>(val);
+		val >>= 8;
+		data[14] = static_cast<uint8_t>(val);
 
-    val >>= 8;
-    data[13] = static_cast<uint8_t>(val);
+		val >>= 8;
+		data[13] = static_cast<uint8_t>(val);
 
-    val >>= 8;
-    data[12] = static_cast<uint8_t>(val);
+		val >>= 8;
+		data[12] = static_cast<uint8_t>(val);
 
-    val >>= 8;
-    data[11] = static_cast<uint8_t>(val);
+		val >>= 8;
+		data[11] = static_cast<uint8_t>(val);
 
-    val >>= 8;
-    data[10] = static_cast<uint8_t>(val);
+		val >>= 8;
+		data[10] = static_cast<uint8_t>(val);
 
-    val >>= 8;
-    data[9] = static_cast<uint8_t>(val);
+		val >>= 8;
+		data[9] = static_cast<uint8_t>(val);
 
-    val >>= 8;
-    data[8] = static_cast<uint8_t>(val);
+		val >>= 8;
+		data[8] = static_cast<uint8_t>(val);
 
-    data[7] = 0;
-    data[6] = 0;
-    data[5] = 0;
-    data[4] = 0;
-    data[3] = 0;
-    data[2] = 0;
-    data[1] = 0;
-    data[0] = 0;
-  }
+		data[7] = 0;
+		data[6] = 0;
+		data[5] = 0;
+		data[4] = 0;
+		data[3] = 0;
+		data[2] = 0;
+		data[1] = 0;
+		data[0] = 0;
+	}
 
-  ULID(const ULID& other) {
-    // for (int i = 0 ; i < 16 ; i++) {
-    // 	data[i] = other.data[i];
-    // }
+	ULID(const ULID& other) {
+		// for (int i = 0 ; i < 16 ; i++) {
+		// 	data[i] = other.data[i];
+		// }
 
-    // unrolled loop
-    data[0] = other.data[0];
-    data[1] = other.data[1];
-    data[2] = other.data[2];
-    data[3] = other.data[3];
-    data[4] = other.data[4];
-    data[5] = other.data[5];
-    data[6] = other.data[6];
-    data[7] = other.data[7];
-    data[8] = other.data[8];
-    data[9] = other.data[9];
-    data[10] = other.data[10];
-    data[11] = other.data[11];
-    data[12] = other.data[12];
-    data[13] = other.data[13];
-    data[14] = other.data[14];
-    data[15] = other.data[15];
-  }
+		// unrolled loop
+		data[0] = other.data[0];
+		data[1] = other.data[1];
+		data[2] = other.data[2];
+		data[3] = other.data[3];
+		data[4] = other.data[4];
+		data[5] = other.data[5];
+		data[6] = other.data[6];
+		data[7] = other.data[7];
+		data[8] = other.data[8];
+		data[9] = other.data[9];
+		data[10] = other.data[10];
+		data[11] = other.data[11];
+		data[12] = other.data[12];
+		data[13] = other.data[13];
+		data[14] = other.data[14];
+		data[15] = other.data[15];
+	}
 
-  ULID& operator=(const ULID& other) {
-    // for (int i = 0 ; i < 16 ; i++) {
-    // 	data[i] = other.data[i];
-    // }
+	ULID& operator=(const ULID& other) {
+		// for (int i = 0 ; i < 16 ; i++) {
+		// 	data[i] = other.data[i];
+		// }
 
-    // unrolled loop
-    data[0] = other.data[0];
-    data[1] = other.data[1];
-    data[2] = other.data[2];
-    data[3] = other.data[3];
-    data[4] = other.data[4];
-    data[5] = other.data[5];
-    data[6] = other.data[6];
-    data[7] = other.data[7];
-    data[8] = other.data[8];
-    data[9] = other.data[9];
-    data[10] = other.data[10];
-    data[11] = other.data[11];
-    data[12] = other.data[12];
-    data[13] = other.data[13];
-    data[14] = other.data[14];
-    data[15] = other.data[15];
+		// unrolled loop
+		data[0] = other.data[0];
+		data[1] = other.data[1];
+		data[2] = other.data[2];
+		data[3] = other.data[3];
+		data[4] = other.data[4];
+		data[5] = other.data[5];
+		data[6] = other.data[6];
+		data[7] = other.data[7];
+		data[8] = other.data[8];
+		data[9] = other.data[9];
+		data[10] = other.data[10];
+		data[11] = other.data[11];
+		data[12] = other.data[12];
+		data[13] = other.data[13];
+		data[14] = other.data[14];
+		data[15] = other.data[15];
 
-    return *this;
-  }
+		return *this;
+	}
 
-  ULID(ULID&& other) {
-    // for (int i = 0 ; i < 16 ; i++) {
-    // 	data[i] = other.data[i];
-    // 	other.data[i] = 0;
-    // }
+	ULID(ULID&& other) {
+		// for (int i = 0 ; i < 16 ; i++) {
+		// 	data[i] = other.data[i];
+		// 	other.data[i] = 0;
+		// }
 
-    // unrolled loop
-    data[0] = other.data[0];
-    other.data[0] = 0;
+		// unrolled loop
+		data[0] = other.data[0];
+		other.data[0] = 0;
 
-    data[1] = other.data[1];
-    other.data[1] = 0;
+		data[1] = other.data[1];
+		other.data[1] = 0;
 
-    data[2] = other.data[2];
-    other.data[2] = 0;
+		data[2] = other.data[2];
+		other.data[2] = 0;
 
-    data[3] = other.data[3];
-    other.data[3] = 0;
+		data[3] = other.data[3];
+		other.data[3] = 0;
 
-    data[4] = other.data[4];
-    other.data[4] = 0;
+		data[4] = other.data[4];
+		other.data[4] = 0;
 
-    data[5] = other.data[5];
-    other.data[5] = 0;
+		data[5] = other.data[5];
+		other.data[5] = 0;
 
-    data[6] = other.data[6];
-    other.data[6] = 0;
+		data[6] = other.data[6];
+		other.data[6] = 0;
 
-    data[7] = other.data[7];
-    other.data[7] = 0;
+		data[7] = other.data[7];
+		other.data[7] = 0;
 
-    data[8] = other.data[8];
-    other.data[8] = 0;
+		data[8] = other.data[8];
+		other.data[8] = 0;
 
-    data[9] = other.data[9];
-    other.data[9] = 0;
+		data[9] = other.data[9];
+		other.data[9] = 0;
 
-    data[10] = other.data[10];
-    other.data[10] = 0;
+		data[10] = other.data[10];
+		other.data[10] = 0;
 
-    data[11] = other.data[11];
-    other.data[11] = 0;
+		data[11] = other.data[11];
+		other.data[11] = 0;
 
-    data[12] = other.data[12];
-    other.data[12] = 0;
+		data[12] = other.data[12];
+		other.data[12] = 0;
 
-    data[13] = other.data[13];
-    other.data[13] = 0;
+		data[13] = other.data[13];
+		other.data[13] = 0;
 
-    data[14] = other.data[14];
-    other.data[14] = 0;
+		data[14] = other.data[14];
+		other.data[14] = 0;
 
-    data[15] = other.data[15];
-    other.data[15] = 0;
-  }
+		data[15] = other.data[15];
+		other.data[15] = 0;
+	}
 
-  ULID& operator=(ULID&& other) {
-    // for (int i = 0 ; i < 16 ; i++) {
-    // 	data[i] = other.data[i];
-    // 	other.data[i] = 0;
-    // }
+	ULID& operator=(ULID&& other) {
+		// for (int i = 0 ; i < 16 ; i++) {
+		// 	data[i] = other.data[i];
+		// 	other.data[i] = 0;
+		// }
 
-    // unrolled loop
-    data[0] = other.data[0];
-    other.data[0] = 0;
+		// unrolled loop
+		data[0] = other.data[0];
+		other.data[0] = 0;
 
-    data[1] = other.data[1];
-    other.data[1] = 0;
+		data[1] = other.data[1];
+		other.data[1] = 0;
 
-    data[2] = other.data[2];
-    other.data[2] = 0;
+		data[2] = other.data[2];
+		other.data[2] = 0;
 
-    data[3] = other.data[3];
-    other.data[3] = 0;
+		data[3] = other.data[3];
+		other.data[3] = 0;
 
-    data[4] = other.data[4];
-    other.data[4] = 0;
+		data[4] = other.data[4];
+		other.data[4] = 0;
 
-    data[5] = other.data[5];
-    other.data[5] = 0;
+		data[5] = other.data[5];
+		other.data[5] = 0;
 
-    data[6] = other.data[6];
-    other.data[6] = 0;
+		data[6] = other.data[6];
+		other.data[6] = 0;
 
-    data[7] = other.data[7];
-    other.data[7] = 0;
+		data[7] = other.data[7];
+		other.data[7] = 0;
 
-    data[8] = other.data[8];
-    other.data[8] = 0;
+		data[8] = other.data[8];
+		other.data[8] = 0;
 
-    data[9] = other.data[9];
-    other.data[9] = 0;
+		data[9] = other.data[9];
+		other.data[9] = 0;
 
-    data[10] = other.data[10];
-    other.data[10] = 0;
+		data[10] = other.data[10];
+		other.data[10] = 0;
 
-    data[11] = other.data[11];
-    other.data[11] = 0;
+		data[11] = other.data[11];
+		other.data[11] = 0;
 
-    data[12] = other.data[12];
-    other.data[12] = 0;
+		data[12] = other.data[12];
+		other.data[12] = 0;
 
-    data[13] = other.data[13];
-    other.data[13] = 0;
+		data[13] = other.data[13];
+		other.data[13] = 0;
 
-    data[14] = other.data[14];
-    other.data[14] = 0;
+		data[14] = other.data[14];
+		other.data[14] = 0;
 
-    data[15] = other.data[15];
-    other.data[15] = 0;
+		data[15] = other.data[15];
+		other.data[15] = 0;
 
-    return *this;
-  }
+		return *this;
+	}
 };
 
 /**
- * EncodeTime will encode the first 6 bytes of a uint8_t array to the passed
- * timestamp
+ * EncodeTime will encode the time point to the passed ulid
  * */
-inline void EncodeTime(time_t timestamp, ULID& ulid) {
-  ulid.data[0] = static_cast<uint8_t>(timestamp >> 40);
-  ulid.data[1] = static_cast<uint8_t>(timestamp >> 32);
-  ulid.data[2] = static_cast<uint8_t>(timestamp >> 24);
-  ulid.data[3] = static_cast<uint8_t>(timestamp >> 16);
-  ulid.data[4] = static_cast<uint8_t>(timestamp >> 8);
-  ulid.data[5] = static_cast<uint8_t>(timestamp);
+inline void EncodeTime(std::chrono::time_point<std::chrono::system_clock> time_point, ULID& ulid) {
+	auto time_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(time_point);
+	int64_t timestamp = time_ms.time_since_epoch().count();
+	ulid.data[0] = static_cast<uint8_t>(timestamp >> 40);
+	ulid.data[1] = static_cast<uint8_t>(timestamp >> 32);
+	ulid.data[2] = static_cast<uint8_t>(timestamp >> 24);
+	ulid.data[3] = static_cast<uint8_t>(timestamp >> 16);
+	ulid.data[4] = static_cast<uint8_t>(timestamp >> 8);
+	ulid.data[5] = static_cast<uint8_t>(timestamp);
 }
 
 /**
  * EncodeTimeNow will encode a ULID using the time obtained using std::time(nullptr)
  * */
 inline void EncodeTimeNow(ULID& ulid) {
-  EncodeTime(std::time(nullptr), ulid);
+	auto time_now = std::chrono::system_clock::from_time_t(time(nullptr));
+	EncodeTime(time_now, ulid);
 }
 
 /**
@@ -272,9 +274,7 @@ inline void EncodeTimeNow(ULID& ulid) {
  * std::chrono::system_clock::now() by taking the timestamp in milliseconds.
  * */
 inline void EncodeTimeSystemClockNow(ULID& ulid) {
-  auto now = std::chrono::system_clock::now();
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
-  EncodeTime(ms.count(), ulid);
+	EncodeTime(std::chrono::system_clock::now(), ulid);
 }
 
 /**
@@ -282,16 +282,16 @@ inline void EncodeTimeSystemClockNow(ULID& ulid) {
  * the values generated using the passed random number generator.
  * */
 inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid) {
-  ulid.data[6] = rng();
-  ulid.data[7] = rng();
-  ulid.data[8] = rng();
-  ulid.data[9] = rng();
-  ulid.data[10] = rng();
-  ulid.data[11] = rng();
-  ulid.data[12] = rng();
-  ulid.data[13] = rng();
-  ulid.data[14] = rng();
-  ulid.data[15] = rng();
+	ulid.data[6] = rng();
+	ulid.data[7] = rng();
+	ulid.data[8] = rng();
+	ulid.data[9] = rng();
+	ulid.data[10] = rng();
+	ulid.data[11] = rng();
+	ulid.data[12] = rng();
+	ulid.data[13] = rng();
+	ulid.data[14] = rng();
+	ulid.data[15] = rng();
 }
 
 /**
@@ -299,17 +299,17 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid) {
  *
  * std::rand returns values in [0, RAND_MAX]
  * */
-void EncodeEntropyRand(ULID& ulid) {
-	ulid.data[6] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[7] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[8] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[9] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[10] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[11] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[12] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[13] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[14] = (intrand() * 255ull) / RAND_MAX;
-	ulid.data[15] = (intrand() * 255ull) / RAND_MAX;
+inline void EncodeEntropyRand(ULID& ulid) {
+	ulid.data[6] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[7] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[8] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[9] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[10] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[11] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[12] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[13] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[14] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
+	ulid.data[15] = static_cast<uint8_t>((intrand() * 255ull) / RAND_MAX);
 	// ulid.data[6] = (std::rand() * 255ull) / RAND_MAX;
 	// ulid.data[7] = (std::rand() * 255ull) / RAND_MAX;
 	// ulid.data[8] = (std::rand() * 255ull) / RAND_MAX;
@@ -320,6 +320,7 @@ void EncodeEntropyRand(ULID& ulid) {
 	// ulid.data[13] = (std::rand() * 255ull) / RAND_MAX;
 	// ulid.data[14] = (std::rand() * 255ull) / RAND_MAX;
 	// ulid.data[15] = (std::rand() * 255ull) / RAND_MAX;
+
 }
 
 static std::uniform_int_distribution<uint8_t> Distribution_0_255(0, 255);
@@ -330,50 +331,50 @@ static std::uniform_int_distribution<uint8_t> Distribution_0_255(0, 255);
  * It also creates a std::uniform_int_distribution to generate values in [0, 255]
  * */
 inline void EncodeEntropyMt19937(std::mt19937& generator, ULID& ulid) {
-  ulid.data[6] = Distribution_0_255(generator);
-  ulid.data[7] = Distribution_0_255(generator);
-  ulid.data[8] = Distribution_0_255(generator);
-  ulid.data[9] = Distribution_0_255(generator);
-  ulid.data[10] = Distribution_0_255(generator);
-  ulid.data[11] = Distribution_0_255(generator);
-  ulid.data[12] = Distribution_0_255(generator);
-  ulid.data[13] = Distribution_0_255(generator);
-  ulid.data[14] = Distribution_0_255(generator);
-  ulid.data[15] = Distribution_0_255(generator);
+	ulid.data[6] = Distribution_0_255(generator);
+	ulid.data[7] = Distribution_0_255(generator);
+	ulid.data[8] = Distribution_0_255(generator);
+	ulid.data[9] = Distribution_0_255(generator);
+	ulid.data[10] = Distribution_0_255(generator);
+	ulid.data[11] = Distribution_0_255(generator);
+	ulid.data[12] = Distribution_0_255(generator);
+	ulid.data[13] = Distribution_0_255(generator);
+	ulid.data[14] = Distribution_0_255(generator);
+	ulid.data[15] = Distribution_0_255(generator);
 }
 
 /**
  * Encode will create an encoded ULID with a timestamp and a generator.
  * */
-inline void Encode(time_t timestamp, const std::function<uint8_t()>& rng, ULID& ulid) {
-  EncodeTime(timestamp, ulid);
-  EncodeEntropy(rng, ulid);
+inline void Encode(std::chrono::time_point<std::chrono::system_clock> timestamp, const std::function<uint8_t()>& rng, ULID& ulid) {
+	EncodeTime(timestamp, ulid);
+	EncodeEntropy(rng, ulid);
 }
 
 /**
  * EncodeNowRand = EncodeTimeNow + EncodeEntropyRand.
  * */
 inline void EncodeNowRand(ULID& ulid) {
-  EncodeTimeNow(ulid);
-  EncodeEntropyRand(ulid);
+	EncodeTimeSystemClockNow(ulid);
+	EncodeEntropyRand(ulid);
 }
 
 /**
  * Create will create a ULID with a timestamp and a generator.
  * */
-inline ULID Create(time_t timestamp, const std::function<uint8_t()>& rng) {
-  ULID ulid;
-  Encode(timestamp, rng, ulid);
-  return ulid;
+inline ULID Create(std::chrono::time_point<std::chrono::system_clock> timestamp, const std::function<uint8_t()>& rng) {
+	ULID ulid;
+	Encode(timestamp, rng, ulid);
+	return ulid;
 }
 
 /**
  * CreateNowRand:EncodeNowRand = Create:Encode.
  * */
 inline ULID CreateNowRand() {
-  ULID ulid;
-  EncodeNowRand(ulid);
-  return ulid;
+	ULID ulid;
+	EncodeNowRand(ulid);
+	return ulid;
 }
 
 /**
@@ -403,79 +404,79 @@ static const char Encoding[33] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
  * follows similarly, except now all components are set to 5 bits.
  * */
 inline void MarshalTo(const ULID& ulid, char dst[26]) {
-  // 10 byte timestamp
-  dst[0] = Encoding[(ulid.data[0] & 224) >> 5];
-  dst[1] = Encoding[ulid.data[0] & 31];
-  dst[2] = Encoding[(ulid.data[1] & 248) >> 3];
-  dst[3] = Encoding[((ulid.data[1] & 7) << 2) | ((ulid.data[2] & 192) >> 6)];
-  dst[4] = Encoding[(ulid.data[2] & 62) >> 1];
-  dst[5] = Encoding[((ulid.data[2] & 1) << 4) | ((ulid.data[3] & 240) >> 4)];
-  dst[6] = Encoding[((ulid.data[3] & 15) << 1) | ((ulid.data[4] & 128) >> 7)];
-  dst[7] = Encoding[(ulid.data[4] & 124) >> 2];
-  dst[8] = Encoding[((ulid.data[4] & 3) << 3) | ((ulid.data[5] & 224) >> 5)];
-  dst[9] = Encoding[ulid.data[5] & 31];
+	// 10 byte timestamp
+	dst[0] = Encoding[(ulid.data[0] & 224) >> 5];
+	dst[1] = Encoding[ulid.data[0] & 31];
+	dst[2] = Encoding[(ulid.data[1] & 248) >> 3];
+	dst[3] = Encoding[((ulid.data[1] & 7) << 2) | ((ulid.data[2] & 192) >> 6)];
+	dst[4] = Encoding[(ulid.data[2] & 62) >> 1];
+	dst[5] = Encoding[((ulid.data[2] & 1) << 4) | ((ulid.data[3] & 240) >> 4)];
+	dst[6] = Encoding[((ulid.data[3] & 15) << 1) | ((ulid.data[4] & 128) >> 7)];
+	dst[7] = Encoding[(ulid.data[4] & 124) >> 2];
+	dst[8] = Encoding[((ulid.data[4] & 3) << 3) | ((ulid.data[5] & 224) >> 5)];
+	dst[9] = Encoding[ulid.data[5] & 31];
 
-  // 16 bytes of entropy
-  dst[10] = Encoding[(ulid.data[6] & 248) >> 3];
-  dst[11] = Encoding[((ulid.data[6] & 7) << 2) | ((ulid.data[7] & 192) >> 6)];
-  dst[12] = Encoding[(ulid.data[7] & 62) >> 1];
-  dst[13] = Encoding[((ulid.data[7] & 1) << 4) | ((ulid.data[8] & 240) >> 4)];
-  dst[14] = Encoding[((ulid.data[8] & 15) << 1) | ((ulid.data[9] & 128) >> 7)];
-  dst[15] = Encoding[(ulid.data[9] & 124) >> 2];
-  dst[16] = Encoding[((ulid.data[9] & 3) << 3) | ((ulid.data[10] & 224) >> 5)];
-  dst[17] = Encoding[ulid.data[10] & 31];
-  dst[18] = Encoding[(ulid.data[11] & 248) >> 3];
-  dst[19] = Encoding[((ulid.data[11] & 7) << 2) | ((ulid.data[12] & 192) >> 6)];
-  dst[20] = Encoding[(ulid.data[12] & 62) >> 1];
-  dst[21] = Encoding[((ulid.data[12] & 1) << 4) | ((ulid.data[13] & 240) >> 4)];
-  dst[22] = Encoding[((ulid.data[13] & 15) << 1) | ((ulid.data[14] & 128) >> 7)];
-  dst[23] = Encoding[(ulid.data[14] & 124) >> 2];
-  dst[24] = Encoding[((ulid.data[14] & 3) << 3) | ((ulid.data[15] & 224) >> 5)];
-  dst[25] = Encoding[ulid.data[15] & 31];
+	// 16 bytes of entropy
+	dst[10] = Encoding[(ulid.data[6] & 248) >> 3];
+	dst[11] = Encoding[((ulid.data[6] & 7) << 2) | ((ulid.data[7] & 192) >> 6)];
+	dst[12] = Encoding[(ulid.data[7] & 62) >> 1];
+	dst[13] = Encoding[((ulid.data[7] & 1) << 4) | ((ulid.data[8] & 240) >> 4)];
+	dst[14] = Encoding[((ulid.data[8] & 15) << 1) | ((ulid.data[9] & 128) >> 7)];
+	dst[15] = Encoding[(ulid.data[9] & 124) >> 2];
+	dst[16] = Encoding[((ulid.data[9] & 3) << 3) | ((ulid.data[10] & 224) >> 5)];
+	dst[17] = Encoding[ulid.data[10] & 31];
+	dst[18] = Encoding[(ulid.data[11] & 248) >> 3];
+	dst[19] = Encoding[((ulid.data[11] & 7) << 2) | ((ulid.data[12] & 192) >> 6)];
+	dst[20] = Encoding[(ulid.data[12] & 62) >> 1];
+	dst[21] = Encoding[((ulid.data[12] & 1) << 4) | ((ulid.data[13] & 240) >> 4)];
+	dst[22] = Encoding[((ulid.data[13] & 15) << 1) | ((ulid.data[14] & 128) >> 7)];
+	dst[23] = Encoding[(ulid.data[14] & 124) >> 2];
+	dst[24] = Encoding[((ulid.data[14] & 3) << 3) | ((ulid.data[15] & 224) >> 5)];
+	dst[25] = Encoding[ulid.data[15] & 31];
 }
 
 /**
  * Marshal will marshal a ULID to a std::string.
  * */
 inline std::string Marshal(const ULID& ulid) {
-  char data[27];
-  data[26] = '\0';
-  MarshalTo(ulid, data);
-  return std::string(data);
+	char data[27];
+	data[26] = '\0';
+	MarshalTo(ulid, data);
+	return std::string(data);
 }
 
 /**
  * MarshalBinaryTo will Marshal a ULID to the passed byte array
  * */
 inline void MarshalBinaryTo(const ULID& ulid, uint8_t dst[16]) {
-  // timestamp
-  dst[0] = ulid.data[0];
-  dst[1] = ulid.data[1];
-  dst[2] = ulid.data[2];
-  dst[3] = ulid.data[3];
-  dst[4] = ulid.data[4];
-  dst[5] = ulid.data[5];
+	// timestamp
+	dst[0] = ulid.data[0];
+	dst[1] = ulid.data[1];
+	dst[2] = ulid.data[2];
+	dst[3] = ulid.data[3];
+	dst[4] = ulid.data[4];
+	dst[5] = ulid.data[5];
 
-  // entropy
-  dst[6] = ulid.data[6];
-  dst[7] = ulid.data[7];
-  dst[8] = ulid.data[8];
-  dst[9] = ulid.data[9];
-  dst[10] = ulid.data[10];
-  dst[11] = ulid.data[11];
-  dst[12] = ulid.data[12];
-  dst[13] = ulid.data[13];
-  dst[14] = ulid.data[14];
-  dst[15] = ulid.data[15];
+	// entropy
+	dst[6] = ulid.data[6];
+	dst[7] = ulid.data[7];
+	dst[8] = ulid.data[8];
+	dst[9] = ulid.data[9];
+	dst[10] = ulid.data[10];
+	dst[11] = ulid.data[11];
+	dst[12] = ulid.data[12];
+	dst[13] = ulid.data[13];
+	dst[14] = ulid.data[14];
+	dst[15] = ulid.data[15];
 }
 
 /**
  * MarshalBinary will Marshal a ULID to a byte vector.
  * */
 inline std::vector<uint8_t> MarshalBinary(const ULID& ulid) {
-  std::vector<uint8_t> dst(16);
-  MarshalBinaryTo(ulid, dst.data());
-  return dst;
+	std::vector<uint8_t> dst(16);
+	MarshalBinaryTo(ulid, dst.data());
+	return dst;
 }
 
 /**
@@ -485,119 +486,119 @@ inline std::vector<uint8_t> MarshalBinary(const ULID& ulid) {
  * 65-90 are capital alphabets.
  * */
 static const uint8_t dec[256] = {
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  /* 0     1     2     3     4     5     6     7  */
-  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-  /* 8     9                                      */
-  0x08, 0x09, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	/* 0     1     2     3     4     5     6     7  */
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	/* 8     9                                      */
+	0x08, 0x09, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  /*    10(A) 11(B) 12(C) 13(D) 14(E) 15(F) 16(G) */
-  0xFF, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
-  /*17(H)     18(J) 19(K)       20(M) 21(N)       */
-  0x11, 0xFF, 0x12, 0x13, 0xFF, 0x14, 0x15, 0xFF,
-  /*22(P)23(Q)24(R) 25(S) 26(T)       27(V) 28(W) */
-  0x16, 0x17, 0x18, 0x19, 0x1A, 0xFF, 0x1B, 0x1C,
-  /*29(X)30(Y)31(Z)                               */
-  0x1D, 0x1E, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	/*    10(A) 11(B) 12(C) 13(D) 14(E) 15(F) 16(G) */
+	0xFF, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+	/*17(H)     18(J) 19(K)       20(M) 21(N)       */
+	0x11, 0xFF, 0x12, 0x13, 0xFF, 0x14, 0x15, 0xFF,
+	/*22(P)23(Q)24(R) 25(S) 26(T)       27(V) 28(W) */
+	0x16, 0x17, 0x18, 0x19, 0x1A, 0xFF, 0x1B, 0x1C,
+	/*29(X)30(Y)31(Z)                               */
+	0x1D, 0x1E, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 };
 
 /**
  * UnmarshalFrom will unmarshal a ULID from the passed character array.
  * */
 inline void UnmarshalFrom(const char str[26], ULID& ulid) {
-  // timestamp
-  ulid.data[0] = (dec[int(str[0])] << 5) | dec[int(str[1])];
-  ulid.data[1] = (dec[int(str[2])] << 3) | (dec[int(str[3])] >> 2);
-  ulid.data[2] = (dec[int(str[3])] << 6) | (dec[int(str[4])] << 1) | (dec[int(str[5])] >> 4);
-  ulid.data[3] = (dec[int(str[5])] << 4) | (dec[int(str[6])] >> 1);
-  ulid.data[4] = (dec[int(str[6])] << 7) | (dec[int(str[7])] << 2) | (dec[int(str[8])] >> 3);
-  ulid.data[5] = (dec[int(str[8])] << 5) | dec[int(str[9])];
+	// timestamp
+	ulid.data[0] = (dec[int(str[0])] << 5) | dec[int(str[1])];
+	ulid.data[1] = (dec[int(str[2])] << 3) | (dec[int(str[3])] >> 2);
+	ulid.data[2] = (dec[int(str[3])] << 6) | (dec[int(str[4])] << 1) | (dec[int(str[5])] >> 4);
+	ulid.data[3] = (dec[int(str[5])] << 4) | (dec[int(str[6])] >> 1);
+	ulid.data[4] = (dec[int(str[6])] << 7) | (dec[int(str[7])] << 2) | (dec[int(str[8])] >> 3);
+	ulid.data[5] = (dec[int(str[8])] << 5) | dec[int(str[9])];
 
-  // entropy
-  ulid.data[6] = (dec[int(str[10])] << 3) | (dec[int(str[11])] >> 2);
-  ulid.data[7] = (dec[int(str[11])] << 6) | (dec[int(str[12])] << 1) | (dec[int(str[13])] >> 4);
-  ulid.data[8] = (dec[int(str[13])] << 4) | (dec[int(str[14])] >> 1);
-  ulid.data[9] = (dec[int(str[14])] << 7) | (dec[int(str[15])] << 2) | (dec[int(str[16])] >> 3);
-  ulid.data[10] = (dec[int(str[16])] << 5) | dec[int(str[17])];
-  ulid.data[11] = (dec[int(str[18])] << 3) | (dec[int(str[19])] >> 2);
-  ulid.data[12] = (dec[int(str[19])] << 6) | (dec[int(str[20])] << 1) | (dec[int(str[21])] >> 4);
-  ulid.data[13] = (dec[int(str[21])] << 4) | (dec[int(str[22])] >> 1);
-  ulid.data[14] = (dec[int(str[22])] << 7) | (dec[int(str[23])] << 2) | (dec[int(str[24])] >> 3);
-  ulid.data[15] = (dec[int(str[24])] << 5) | dec[int(str[25])];
+	// entropy
+	ulid.data[6] = (dec[int(str[10])] << 3) | (dec[int(str[11])] >> 2);
+	ulid.data[7] = (dec[int(str[11])] << 6) | (dec[int(str[12])] << 1) | (dec[int(str[13])] >> 4);
+	ulid.data[8] = (dec[int(str[13])] << 4) | (dec[int(str[14])] >> 1);
+	ulid.data[9] = (dec[int(str[14])] << 7) | (dec[int(str[15])] << 2) | (dec[int(str[16])] >> 3);
+	ulid.data[10] = (dec[int(str[16])] << 5) | dec[int(str[17])];
+	ulid.data[11] = (dec[int(str[18])] << 3) | (dec[int(str[19])] >> 2);
+	ulid.data[12] = (dec[int(str[19])] << 6) | (dec[int(str[20])] << 1) | (dec[int(str[21])] >> 4);
+	ulid.data[13] = (dec[int(str[21])] << 4) | (dec[int(str[22])] >> 1);
+	ulid.data[14] = (dec[int(str[22])] << 7) | (dec[int(str[23])] << 2) | (dec[int(str[24])] >> 3);
+	ulid.data[15] = (dec[int(str[24])] << 5) | dec[int(str[25])];
 }
 
 /**
  * Unmarshal will create a new ULID by unmarshaling the passed string.
  * */
 inline ULID Unmarshal(const std::string& str) {
-  ULID ulid;
-  UnmarshalFrom(str.c_str(), ulid);
-  return ulid;
+	ULID ulid;
+	UnmarshalFrom(str.c_str(), ulid);
+	return ulid;
 }
 
 /**
  * UnmarshalBinaryFrom will unmarshal a ULID from the passed byte array.
  * */
 inline void UnmarshalBinaryFrom(const uint8_t b[16], ULID& ulid) {
-  // timestamp
-  ulid.data[0] = b[0];
-  ulid.data[1] = b[1];
-  ulid.data[2] = b[2];
-  ulid.data[3] = b[3];
-  ulid.data[4] = b[4];
-  ulid.data[5] = b[5];
+	// timestamp
+	ulid.data[0] = b[0];
+	ulid.data[1] = b[1];
+	ulid.data[2] = b[2];
+	ulid.data[3] = b[3];
+	ulid.data[4] = b[4];
+	ulid.data[5] = b[5];
 
-  // entropy
-  ulid.data[6] = b[6];
-  ulid.data[7] = b[7];
-  ulid.data[8] = b[8];
-  ulid.data[9] = b[9];
-  ulid.data[10] = b[10];
-  ulid.data[11] = b[11];
-  ulid.data[12] = b[12];
-  ulid.data[13] = b[13];
-  ulid.data[14] = b[14];
-  ulid.data[15] = b[15];
+	// entropy
+	ulid.data[6] = b[6];
+	ulid.data[7] = b[7];
+	ulid.data[8] = b[8];
+	ulid.data[9] = b[9];
+	ulid.data[10] = b[10];
+	ulid.data[11] = b[11];
+	ulid.data[12] = b[12];
+	ulid.data[13] = b[13];
+	ulid.data[14] = b[14];
+	ulid.data[15] = b[15];
 }
 
 /**
  * Unmarshal will create a new ULID by unmarshaling the passed byte vector.
  * */
 inline ULID UnmarshalBinary(const std::vector<uint8_t>& b) {
-  ULID ulid;
-  UnmarshalBinaryFrom(b.data(), ulid);
-  return ulid;
+	ULID ulid;
+	UnmarshalBinaryFrom(b.data(), ulid);
+	return ulid;
 }
 
 /**
@@ -608,105 +609,105 @@ inline ULID UnmarshalBinary(const std::vector<uint8_t>& b) {
  *      0 if ulid1 is same as ulid2
  * */
 inline int CompareULIDs(const ULID& ulid1, const ULID& ulid2) {
-  // for (int i = 0 ; i < 16 ; i++) {
-  // 	if (ulid1.data[i] != ulid2.data[i]) {
-  // 		return (ulid1.data[i] < ulid2.data[i]) * -2 + 1;
-  // 	}
-  // }
+	// for (int i = 0 ; i < 16 ; i++) {
+	// 	if (ulid1.data[i] != ulid2.data[i]) {
+	// 		return (ulid1.data[i] < ulid2.data[i]) * -2 + 1;
+	// 	}
+	// }
 
-  // unrolled loop
+	// unrolled loop
 
-  if (ulid1.data[0] != ulid2.data[0]) {
-    return (ulid1.data[0] < ulid2.data[0]) * -2 + 1;
-  }
+	if (ulid1.data[0] != ulid2.data[0]) {
+		return (ulid1.data[0] < ulid2.data[0]) * -2 + 1;
+	}
 
-  if (ulid1.data[1] != ulid2.data[1]) {
-    return (ulid1.data[1] < ulid2.data[1]) * -2 + 1;
-  }
+	if (ulid1.data[1] != ulid2.data[1]) {
+		return (ulid1.data[1] < ulid2.data[1]) * -2 + 1;
+	}
 
-  if (ulid1.data[2] != ulid2.data[2]) {
-    return (ulid1.data[2] < ulid2.data[2]) * -2 + 1;
-  }
+	if (ulid1.data[2] != ulid2.data[2]) {
+		return (ulid1.data[2] < ulid2.data[2]) * -2 + 1;
+	}
 
-  if (ulid1.data[3] != ulid2.data[3]) {
-    return (ulid1.data[3] < ulid2.data[3]) * -2 + 1;
-  }
+	if (ulid1.data[3] != ulid2.data[3]) {
+		return (ulid1.data[3] < ulid2.data[3]) * -2 + 1;
+	}
 
-  if (ulid1.data[4] != ulid2.data[4]) {
-    return (ulid1.data[4] < ulid2.data[4]) * -2 + 1;
-  }
+	if (ulid1.data[4] != ulid2.data[4]) {
+		return (ulid1.data[4] < ulid2.data[4]) * -2 + 1;
+	}
 
-  if (ulid1.data[5] != ulid2.data[5]) {
-    return (ulid1.data[5] < ulid2.data[5]) * -2 + 1;
-  }
+	if (ulid1.data[5] != ulid2.data[5]) {
+		return (ulid1.data[5] < ulid2.data[5]) * -2 + 1;
+	}
 
-  if (ulid1.data[6] != ulid2.data[6]) {
-    return (ulid1.data[6] < ulid2.data[6]) * -2 + 1;
-  }
+	if (ulid1.data[6] != ulid2.data[6]) {
+		return (ulid1.data[6] < ulid2.data[6]) * -2 + 1;
+	}
 
-  if (ulid1.data[7] != ulid2.data[7]) {
-    return (ulid1.data[7] < ulid2.data[7]) * -2 + 1;
-  }
+	if (ulid1.data[7] != ulid2.data[7]) {
+		return (ulid1.data[7] < ulid2.data[7]) * -2 + 1;
+	}
 
-  if (ulid1.data[8] != ulid2.data[8]) {
-    return (ulid1.data[8] < ulid2.data[8]) * -2 + 1;
-  }
+	if (ulid1.data[8] != ulid2.data[8]) {
+		return (ulid1.data[8] < ulid2.data[8]) * -2 + 1;
+	}
 
-  if (ulid1.data[9] != ulid2.data[9]) {
-    return (ulid1.data[9] < ulid2.data[9]) * -2 + 1;
-  }
+	if (ulid1.data[9] != ulid2.data[9]) {
+		return (ulid1.data[9] < ulid2.data[9]) * -2 + 1;
+	}
 
-  if (ulid1.data[10] != ulid2.data[10]) {
-    return (ulid1.data[10] < ulid2.data[10]) * -2 + 1;
-  }
+	if (ulid1.data[10] != ulid2.data[10]) {
+		return (ulid1.data[10] < ulid2.data[10]) * -2 + 1;
+	}
 
-  if (ulid1.data[11] != ulid2.data[11]) {
-    return (ulid1.data[11] < ulid2.data[11]) * -2 + 1;
-  }
+	if (ulid1.data[11] != ulid2.data[11]) {
+		return (ulid1.data[11] < ulid2.data[11]) * -2 + 1;
+	}
 
-  if (ulid1.data[12] != ulid2.data[12]) {
-    return (ulid1.data[12] < ulid2.data[12]) * -2 + 1;
-  }
+	if (ulid1.data[12] != ulid2.data[12]) {
+		return (ulid1.data[12] < ulid2.data[12]) * -2 + 1;
+	}
 
-  if (ulid1.data[13] != ulid2.data[13]) {
-    return (ulid1.data[13] < ulid2.data[13]) * -2 + 1;
-  }
+	if (ulid1.data[13] != ulid2.data[13]) {
+		return (ulid1.data[13] < ulid2.data[13]) * -2 + 1;
+	}
 
-  if (ulid1.data[14] != ulid2.data[14]) {
-    return (ulid1.data[14] < ulid2.data[14]) * -2 + 1;
-  }
+	if (ulid1.data[14] != ulid2.data[14]) {
+		return (ulid1.data[14] < ulid2.data[14]) * -2 + 1;
+	}
 
-  if (ulid1.data[15] != ulid2.data[15]) {
-    return (ulid1.data[15] < ulid2.data[15]) * -2 + 1;
-  }
+	if (ulid1.data[15] != ulid2.data[15]) {
+		return (ulid1.data[15] < ulid2.data[15]) * -2 + 1;
+	}
 
-  return 0;
+	return 0;
 }
 
 /**
  * Time will extract the timestamp used to generate a ULID
  * */
-inline time_t Time(const ULID& ulid) {
-  time_t ans = 0;
+inline std::chrono::time_point<std::chrono::system_clock> Time(const ULID& ulid) {
+	int64_t ans = 0;
 
-  ans |= ulid.data[0];
+	ans |= ulid.data[0];
 
-  ans <<= 8;
-  ans |= ulid.data[1];
+	ans <<= 8;
+	ans |= ulid.data[1];
 
-  ans <<= 8;
-  ans |= ulid.data[2];
+	ans <<= 8;
+	ans |= ulid.data[2];
 
-  ans <<= 8;
-  ans |= ulid.data[3];
+	ans <<= 8;
+	ans |= ulid.data[3];
 
-  ans <<= 8;
-  ans |= ulid.data[4];
+	ans <<= 8;
+	ans |= ulid.data[4];
 
-  ans <<= 8;
-  ans |= ulid.data[5];
+	ans <<= 8;
+	ans |= ulid.data[5];
 
-  return ans;
+	return std::chrono::time_point<std::chrono::system_clock>(std::chrono::milliseconds{ans});
 }
 
 };  // namespace ulid

--- a/src/ulid/ulid_uint128.h
+++ b/src/ulid/ulid_uint128.h
@@ -18,41 +18,43 @@ namespace ulid {
 typedef __uint128_t ULID;
 
 /**
- * EncodeTime will encode the first 6 bytes of a uint8_t array to the passed
- * timestamp
+ * EncodeTime will encode the time point to the passed ulid
  * */
-inline void EncodeTime(time_t timestamp, ULID& ulid) {
-  ULID t = static_cast<uint8_t>(timestamp >> 40);
+inline void EncodeTime(std::chrono::time_point<std::chrono::system_clock> time_point, ULID& ulid) {
+	auto time_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(time_point);
+	int64_t timestamp = time_ms.time_since_epoch().count();
+	ULID t = static_cast<uint8_t>(timestamp >> 40);
 
-  t <<= 8;
-  t |= static_cast<uint8_t>(timestamp >> 32);
+	t <<= 8;
+	t |= static_cast<uint8_t>(timestamp >> 32);
 
-  t <<= 8;
-  t |= static_cast<uint8_t>(timestamp >> 24);
+	t <<= 8;
+	t |= static_cast<uint8_t>(timestamp >> 24);
 
-  t <<= 8;
-  t |= static_cast<uint8_t>(timestamp >> 16);
+	t <<= 8;
+	t |= static_cast<uint8_t>(timestamp >> 16);
 
-  t <<= 8;
-  t |= static_cast<uint8_t>(timestamp >> 8);
+	t <<= 8;
+	t |= static_cast<uint8_t>(timestamp >> 8);
 
-  t <<= 8;
-  t |= static_cast<uint8_t>(timestamp);
+	t <<= 8;
+	t |= static_cast<uint8_t>(timestamp);
 
-  t <<= 80;
+	t <<= 80;
 
-  ULID mask = 1;
-  mask <<= 80;
-  mask--;
+	ULID mask = 1;
+	mask <<= 80;
+	mask--;
 
-  ulid = t | (ulid & mask);
+	ulid = t | (ulid & mask);
 }
 
 /**
  * EncodeTimeNow will encode a ULID using the time obtained using std::time(nullptr)
  * */
 inline void EncodeTimeNow(ULID& ulid) {
-  EncodeTime(std::time(nullptr), ulid);
+	auto time_now = std::chrono::system_clock::from_time_t(time(nullptr));
+	EncodeTime(time_now, ulid);
 }
 
 /**
@@ -60,9 +62,7 @@ inline void EncodeTimeNow(ULID& ulid) {
  * std::chrono::system_clock::now() by taking the timestamp in milliseconds.
  * */
 inline void EncodeTimeSystemClockNow(ULID& ulid) {
-  auto now = std::chrono::system_clock::now();
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
-  EncodeTime(ms.count(), ulid);
+	EncodeTime(std::chrono::system_clock::now(), ulid);
 }
 
 /**
@@ -70,38 +70,38 @@ inline void EncodeTimeSystemClockNow(ULID& ulid) {
  * the values generated using the passed random number generator.
  * */
 inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid) {
-  ulid = (ulid >> 80) << 80;
+	ulid = (ulid >> 80) << 80;
 
-  ULID e = rng();
+	ULID e = rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  e <<= 8;
-  e |= rng();
+	e <<= 8;
+	e |= rng();
 
-  ulid |= e;
+	ulid |= e;
 }
 
 /**
@@ -109,7 +109,7 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid) {
  *
  * std::rand returns values in [0, RAND_MAX]
  * */
-void EncodeEntropyRand(ULID& ulid) {
+inline void EncodeEntropyRand(ULID& ulid) {
 	ulid = (ulid >> 80) << 80;
 
 	ULID e = (intrand() * 255ull) / RAND_MAX;
@@ -140,7 +140,6 @@ void EncodeEntropyRand(ULID& ulid) {
 
 	e <<= 8;
 	e |= (intrand() * 255ull) / RAND_MAX;
-
 
 	// ULID e = (std::rand() * 255ull) / RAND_MAX;
 	//
@@ -182,72 +181,72 @@ static std::uniform_int_distribution<uint8_t> Distribution_0_255(0, 255);
  * It also creates a std::uniform_int_distribution to generate values in [0, 255]
  * */
 inline void EncodeEntropyMt19937(std::mt19937& generator, ULID& ulid) {
-  ulid = (ulid >> 80) << 80;
+	ulid = (ulid >> 80) << 80;
 
-  ULID e = Distribution_0_255(generator);
+	ULID e = Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  e <<= 8;
-  e |= Distribution_0_255(generator);
+	e <<= 8;
+	e |= Distribution_0_255(generator);
 
-  ulid |= e;
+	ulid |= e;
 }
 
 /**
  * Encode will create an encoded ULID with a timestamp and a generator.
  * */
-inline void Encode(time_t timestamp, const std::function<uint8_t()>& rng, ULID& ulid) {
-  EncodeTime(timestamp, ulid);
-  EncodeEntropy(rng, ulid);
+inline void Encode(std::chrono::time_point<std::chrono::system_clock> timestamp, const std::function<uint8_t()>& rng, ULID& ulid) {
+	EncodeTime(timestamp, ulid);
+	EncodeEntropy(rng, ulid);
 }
 
 /**
  * EncodeNowRand = EncodeTimeNow + EncodeEntropyRand.
  * */
 inline void EncodeNowRand(ULID& ulid) {
-  EncodeTimeNow(ulid);
-  EncodeEntropyRand(ulid);
+	EncodeTimeSystemClockNow(ulid);
+	EncodeEntropyRand(ulid);
 }
 
 /**
  * Create will create a ULID with a timestamp and a generator.
  * */
-inline ULID Create(time_t timestamp, const std::function<uint8_t()>& rng) {
-  ULID ulid = 0;
-  Encode(timestamp, rng, ulid);
-  return ulid;
+inline ULID Create(std::chrono::time_point<std::chrono::system_clock> timestamp, const std::function<uint8_t()>& rng) {
+	ULID ulid = 0;
+	Encode(timestamp, rng, ulid);
+	return ulid;
 }
 
 /**
  * CreateNowRand:EncodeNowRand = Create:Encode.
  * */
 inline ULID CreateNowRand() {
-  ULID ulid = 0;
-  EncodeNowRand(ulid);
-  return ulid;
+	ULID ulid = 0;
+	EncodeNowRand(ulid);
+	return ulid;
 }
 
 /**
@@ -277,79 +276,79 @@ static const char Encoding[33] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
  * follows similarly, except now all components are set to 5 bits.
  * */
 inline void MarshalTo(const ULID& ulid, char dst[26]) {
-  // 10 byte timestamp
-  dst[0] = Encoding[(static_cast<uint8_t>(ulid >> 120) & 224) >> 5];
-  dst[1] = Encoding[static_cast<uint8_t>(ulid >> 120) & 31];
-  dst[2] = Encoding[(static_cast<uint8_t>(ulid >> 112) & 248) >> 3];
-  dst[3] = Encoding[((static_cast<uint8_t>(ulid >> 112) & 7) << 2) | ((static_cast<uint8_t>(ulid >> 104) & 192) >> 6)];
-  dst[4] = Encoding[(static_cast<uint8_t>(ulid >> 104) & 62) >> 1];
-  dst[5] = Encoding[((static_cast<uint8_t>(ulid >> 104) & 1) << 4) | ((static_cast<uint8_t>(ulid >> 96) & 240) >> 4)];
-  dst[6] = Encoding[((static_cast<uint8_t>(ulid >> 96) & 15) << 1) | ((static_cast<uint8_t>(ulid >> 88) & 128) >> 7)];
-  dst[7] = Encoding[(static_cast<uint8_t>(ulid >> 88) & 124) >> 2];
-  dst[8] = Encoding[((static_cast<uint8_t>(ulid >> 88) & 3) << 3) | ((static_cast<uint8_t>(ulid >> 80) & 224) >> 5)];
-  dst[9] = Encoding[static_cast<uint8_t>(ulid >> 80) & 31];
+	// 10 byte timestamp
+	dst[0] = Encoding[(static_cast<uint8_t>(ulid >> 120) & 224) >> 5];
+	dst[1] = Encoding[static_cast<uint8_t>(ulid >> 120) & 31];
+	dst[2] = Encoding[(static_cast<uint8_t>(ulid >> 112) & 248) >> 3];
+	dst[3] = Encoding[((static_cast<uint8_t>(ulid >> 112) & 7) << 2) | ((static_cast<uint8_t>(ulid >> 104) & 192) >> 6)];
+	dst[4] = Encoding[(static_cast<uint8_t>(ulid >> 104) & 62) >> 1];
+	dst[5] = Encoding[((static_cast<uint8_t>(ulid >> 104) & 1) << 4) | ((static_cast<uint8_t>(ulid >> 96) & 240) >> 4)];
+	dst[6] = Encoding[((static_cast<uint8_t>(ulid >> 96) & 15) << 1) | ((static_cast<uint8_t>(ulid >> 88) & 128) >> 7)];
+	dst[7] = Encoding[(static_cast<uint8_t>(ulid >> 88) & 124) >> 2];
+	dst[8] = Encoding[((static_cast<uint8_t>(ulid >> 88) & 3) << 3) | ((static_cast<uint8_t>(ulid >> 80) & 224) >> 5)];
+	dst[9] = Encoding[static_cast<uint8_t>(ulid >> 80) & 31];
 
-  // 16 bytes of entropy
-  dst[10] = Encoding[(static_cast<uint8_t>(ulid >> 72) & 248) >> 3];
-  dst[11] = Encoding[((static_cast<uint8_t>(ulid >> 72) & 7) << 2) | ((static_cast<uint8_t>(ulid >> 64) & 192) >> 6)];
-  dst[12] = Encoding[(static_cast<uint8_t>(ulid >> 64) & 62) >> 1];
-  dst[13] = Encoding[((static_cast<uint8_t>(ulid >> 64) & 1) << 4) | ((static_cast<uint8_t>(ulid >> 56) & 240) >> 4)];
-  dst[14] = Encoding[((static_cast<uint8_t>(ulid >> 56) & 15) << 1) | ((static_cast<uint8_t>(ulid >> 48) & 128) >> 7)];
-  dst[15] = Encoding[(static_cast<uint8_t>(ulid >> 48) & 124) >> 2];
-  dst[16] = Encoding[((static_cast<uint8_t>(ulid >> 48) & 3) << 3) | ((static_cast<uint8_t>(ulid >> 40) & 224) >> 5)];
-  dst[17] = Encoding[static_cast<uint8_t>(ulid >> 40) & 31];
-  dst[18] = Encoding[(static_cast<uint8_t>(ulid >> 32) & 248) >> 3];
-  dst[19] = Encoding[((static_cast<uint8_t>(ulid >> 32) & 7) << 2) | ((static_cast<uint8_t>(ulid >> 24) & 192) >> 6)];
-  dst[20] = Encoding[(static_cast<uint8_t>(ulid >> 24) & 62) >> 1];
-  dst[21] = Encoding[((static_cast<uint8_t>(ulid >> 24) & 1) << 4) | ((static_cast<uint8_t>(ulid >> 16) & 240) >> 4)];
-  dst[22] = Encoding[((static_cast<uint8_t>(ulid >> 16) & 15) << 1) | ((static_cast<uint8_t>(ulid >> 8) & 128) >> 7)];
-  dst[23] = Encoding[(static_cast<uint8_t>(ulid >> 8) & 124) >> 2];
-  dst[24] = Encoding[((static_cast<uint8_t>(ulid >> 8) & 3) << 3) | (((static_cast<uint8_t>(ulid)) & 224) >> 5)];
-  dst[25] = Encoding[(static_cast<uint8_t>(ulid)) & 31];
+	// 16 bytes of entropy
+	dst[10] = Encoding[(static_cast<uint8_t>(ulid >> 72) & 248) >> 3];
+	dst[11] = Encoding[((static_cast<uint8_t>(ulid >> 72) & 7) << 2) | ((static_cast<uint8_t>(ulid >> 64) & 192) >> 6)];
+	dst[12] = Encoding[(static_cast<uint8_t>(ulid >> 64) & 62) >> 1];
+	dst[13] = Encoding[((static_cast<uint8_t>(ulid >> 64) & 1) << 4) | ((static_cast<uint8_t>(ulid >> 56) & 240) >> 4)];
+	dst[14] = Encoding[((static_cast<uint8_t>(ulid >> 56) & 15) << 1) | ((static_cast<uint8_t>(ulid >> 48) & 128) >> 7)];
+	dst[15] = Encoding[(static_cast<uint8_t>(ulid >> 48) & 124) >> 2];
+	dst[16] = Encoding[((static_cast<uint8_t>(ulid >> 48) & 3) << 3) | ((static_cast<uint8_t>(ulid >> 40) & 224) >> 5)];
+	dst[17] = Encoding[static_cast<uint8_t>(ulid >> 40) & 31];
+	dst[18] = Encoding[(static_cast<uint8_t>(ulid >> 32) & 248) >> 3];
+	dst[19] = Encoding[((static_cast<uint8_t>(ulid >> 32) & 7) << 2) | ((static_cast<uint8_t>(ulid >> 24) & 192) >> 6)];
+	dst[20] = Encoding[(static_cast<uint8_t>(ulid >> 24) & 62) >> 1];
+	dst[21] = Encoding[((static_cast<uint8_t>(ulid >> 24) & 1) << 4) | ((static_cast<uint8_t>(ulid >> 16) & 240) >> 4)];
+	dst[22] = Encoding[((static_cast<uint8_t>(ulid >> 16) & 15) << 1) | ((static_cast<uint8_t>(ulid >> 8) & 128) >> 7)];
+	dst[23] = Encoding[(static_cast<uint8_t>(ulid >> 8) & 124) >> 2];
+	dst[24] = Encoding[((static_cast<uint8_t>(ulid >> 8) & 3) << 3) | (((static_cast<uint8_t>(ulid)) & 224) >> 5)];
+	dst[25] = Encoding[(static_cast<uint8_t>(ulid)) & 31];
 }
 
 /**
  * Marshal will marshal a ULID to a std::string.
  * */
 inline std::string Marshal(const ULID& ulid) {
-  char data[27];
-  data[26] = '\0';
-  MarshalTo(ulid, data);
-  return std::string(data);
+	char data[27];
+	data[26] = '\0';
+	MarshalTo(ulid, data);
+	return std::string(data);
 }
 
 /**
  * MarshalBinaryTo will Marshal a ULID to the passed byte array
  * */
 inline void MarshalBinaryTo(const ULID& ulid, uint8_t dst[16]) {
-  // timestamp
-  dst[0] = static_cast<uint8_t>(ulid >> 120);
-  dst[1] = static_cast<uint8_t>(ulid >> 112);
-  dst[2] = static_cast<uint8_t>(ulid >> 104);
-  dst[3] = static_cast<uint8_t>(ulid >> 96);
-  dst[4] = static_cast<uint8_t>(ulid >> 88);
-  dst[5] = static_cast<uint8_t>(ulid >> 80);
+	// timestamp
+	dst[0] = static_cast<uint8_t>(ulid >> 120);
+	dst[1] = static_cast<uint8_t>(ulid >> 112);
+	dst[2] = static_cast<uint8_t>(ulid >> 104);
+	dst[3] = static_cast<uint8_t>(ulid >> 96);
+	dst[4] = static_cast<uint8_t>(ulid >> 88);
+	dst[5] = static_cast<uint8_t>(ulid >> 80);
 
-  // entropy
-  dst[6] = static_cast<uint8_t>(ulid >> 72);
-  dst[7] = static_cast<uint8_t>(ulid >> 64);
-  dst[8] = static_cast<uint8_t>(ulid >> 56);
-  dst[9] = static_cast<uint8_t>(ulid >> 48);
-  dst[10] = static_cast<uint8_t>(ulid >> 40);
-  dst[11] = static_cast<uint8_t>(ulid >> 32);
-  dst[12] = static_cast<uint8_t>(ulid >> 24);
-  dst[13] = static_cast<uint8_t>(ulid >> 16);
-  dst[14] = static_cast<uint8_t>(ulid >> 8);
-  dst[15] = static_cast<uint8_t>(ulid);
+	// entropy
+	dst[6] = static_cast<uint8_t>(ulid >> 72);
+	dst[7] = static_cast<uint8_t>(ulid >> 64);
+	dst[8] = static_cast<uint8_t>(ulid >> 56);
+	dst[9] = static_cast<uint8_t>(ulid >> 48);
+	dst[10] = static_cast<uint8_t>(ulid >> 40);
+	dst[11] = static_cast<uint8_t>(ulid >> 32);
+	dst[12] = static_cast<uint8_t>(ulid >> 24);
+	dst[13] = static_cast<uint8_t>(ulid >> 16);
+	dst[14] = static_cast<uint8_t>(ulid >> 8);
+	dst[15] = static_cast<uint8_t>(ulid);
 }
 
 /**
  * MarshalBinary will Marshal a ULID to a byte vector.
  * */
 inline std::vector<uint8_t> MarshalBinary(const ULID& ulid) {
-  std::vector<uint8_t> dst(16);
-  MarshalBinaryTo(ulid, dst.data());
-  return dst;
+	std::vector<uint8_t> dst(16);
+	MarshalBinaryTo(ulid, dst.data());
+	return dst;
 }
 
 /**
@@ -359,177 +358,177 @@ inline std::vector<uint8_t> MarshalBinary(const ULID& ulid) {
  * 65-90 are capital alphabets.
  * */
 static const uint8_t dec[256] = {
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  /* 0     1     2     3     4     5     6     7  */
-  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-  /* 8     9                                      */
-  0x08, 0x09, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	/* 0     1     2     3     4     5     6     7  */
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	/* 8     9                                      */
+	0x08, 0x09, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  /*    10(A) 11(B) 12(C) 13(D) 14(E) 15(F) 16(G) */
-  0xFF, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
-  /*17(H)     18(J) 19(K)       20(M) 21(N)       */
-  0x11, 0xFF, 0x12, 0x13, 0xFF, 0x14, 0x15, 0xFF,
-  /*22(P)23(Q)24(R) 25(S) 26(T)       27(V) 28(W) */
-  0x16, 0x17, 0x18, 0x19, 0x1A, 0xFF, 0x1B, 0x1C,
-  /*29(X)30(Y)31(Z)                               */
-  0x1D, 0x1E, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	/*    10(A) 11(B) 12(C) 13(D) 14(E) 15(F) 16(G) */
+	0xFF, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+	/*17(H)     18(J) 19(K)       20(M) 21(N)       */
+	0x11, 0xFF, 0x12, 0x13, 0xFF, 0x14, 0x15, 0xFF,
+	/*22(P)23(Q)24(R) 25(S) 26(T)       27(V) 28(W) */
+	0x16, 0x17, 0x18, 0x19, 0x1A, 0xFF, 0x1B, 0x1C,
+	/*29(X)30(Y)31(Z)                               */
+	0x1D, 0x1E, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 };
 
 /**
  * UnmarshalFrom will unmarshal a ULID from the passed character array.
  * */
 inline void UnmarshalFrom(const char str[26], ULID& ulid) {
-  // timestamp
-  ulid = (dec[int(str[0])] << 5) | dec[int(str[1])];
+	// timestamp
+	ulid = (dec[int(str[0])] << 5) | dec[int(str[1])];
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[2])] << 3) | (dec[int(str[3])] >> 2);
+	ulid <<= 8;
+	ulid |= (dec[int(str[2])] << 3) | (dec[int(str[3])] >> 2);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[3])] << 6) | (dec[int(str[4])] << 1) | (dec[int(str[5])] >> 4);
+	ulid <<= 8;
+	ulid |= (dec[int(str[3])] << 6) | (dec[int(str[4])] << 1) | (dec[int(str[5])] >> 4);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[5])] << 4) | (dec[int(str[6])] >> 1);
+	ulid <<= 8;
+	ulid |= (dec[int(str[5])] << 4) | (dec[int(str[6])] >> 1);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[6])] << 7) | (dec[int(str[7])] << 2) | (dec[int(str[8])] >> 3);
+	ulid <<= 8;
+	ulid |= (dec[int(str[6])] << 7) | (dec[int(str[7])] << 2) | (dec[int(str[8])] >> 3);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[8])] << 5) | dec[int(str[9])];
+	ulid <<= 8;
+	ulid |= (dec[int(str[8])] << 5) | dec[int(str[9])];
 
-  // entropy
-  ulid <<= 8;
-  ulid |= (dec[int(str[10])] << 3) | (dec[int(str[11])] >> 2);
+	// entropy
+	ulid <<= 8;
+	ulid |= (dec[int(str[10])] << 3) | (dec[int(str[11])] >> 2);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[11])] << 6) | (dec[int(str[12])] << 1) | (dec[int(str[13])] >> 4);
+	ulid <<= 8;
+	ulid |= (dec[int(str[11])] << 6) | (dec[int(str[12])] << 1) | (dec[int(str[13])] >> 4);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[13])] << 4) | (dec[int(str[14])] >> 1);
+	ulid <<= 8;
+	ulid |= (dec[int(str[13])] << 4) | (dec[int(str[14])] >> 1);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[14])] << 7) | (dec[int(str[15])] << 2) | (dec[int(str[16])] >> 3);
+	ulid <<= 8;
+	ulid |= (dec[int(str[14])] << 7) | (dec[int(str[15])] << 2) | (dec[int(str[16])] >> 3);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[16])] << 5) | dec[int(str[17])];
+	ulid <<= 8;
+	ulid |= (dec[int(str[16])] << 5) | dec[int(str[17])];
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[18])] << 3) | (dec[int(str[19])] >> 2);
+	ulid <<= 8;
+	ulid |= (dec[int(str[18])] << 3) | (dec[int(str[19])] >> 2);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[19])] << 6) | (dec[int(str[20])] << 1) | (dec[int(str[21])] >> 4);
+	ulid <<= 8;
+	ulid |= (dec[int(str[19])] << 6) | (dec[int(str[20])] << 1) | (dec[int(str[21])] >> 4);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[21])] << 4) | (dec[int(str[22])] >> 1);
+	ulid <<= 8;
+	ulid |= (dec[int(str[21])] << 4) | (dec[int(str[22])] >> 1);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[22])] << 7) | (dec[int(str[23])] << 2) | (dec[int(str[24])] >> 3);
+	ulid <<= 8;
+	ulid |= (dec[int(str[22])] << 7) | (dec[int(str[23])] << 2) | (dec[int(str[24])] >> 3);
 
-  ulid <<= 8;
-  ulid |= (dec[int(str[24])] << 5) | dec[int(str[25])];
+	ulid <<= 8;
+	ulid |= (dec[int(str[24])] << 5) | dec[int(str[25])];
 }
 
 /**
  * Unmarshal will create a new ULID by unmarshaling the passed string.
  * */
 inline ULID Unmarshal(const std::string& str) {
-  ULID ulid;
-  UnmarshalFrom(str.c_str(), ulid);
-  return ulid;
+	ULID ulid;
+	UnmarshalFrom(str.c_str(), ulid);
+	return ulid;
 }
 
 /**
  * UnmarshalBinaryFrom will unmarshal a ULID from the passed byte array.
  * */
 inline void UnmarshalBinaryFrom(const uint8_t b[16], ULID& ulid) {
-  // timestamp
-  ulid = b[0];
+	// timestamp
+	ulid = b[0];
 
-  ulid <<= 8;
-  ulid |= b[1];
+	ulid <<= 8;
+	ulid |= b[1];
 
-  ulid <<= 8;
-  ulid |= b[2];
+	ulid <<= 8;
+	ulid |= b[2];
 
-  ulid <<= 8;
-  ulid |= b[3];
+	ulid <<= 8;
+	ulid |= b[3];
 
-  ulid <<= 8;
-  ulid |= b[4];
+	ulid <<= 8;
+	ulid |= b[4];
 
-  ulid <<= 8;
-  ulid |= b[5];
+	ulid <<= 8;
+	ulid |= b[5];
 
-  // entropy
-  ulid <<= 8;
-  ulid |= b[6];
+	// entropy
+	ulid <<= 8;
+	ulid |= b[6];
 
-  ulid <<= 8;
-  ulid |= b[7];
+	ulid <<= 8;
+	ulid |= b[7];
 
-  ulid <<= 8;
-  ulid |= b[8];
+	ulid <<= 8;
+	ulid |= b[8];
 
-  ulid <<= 8;
-  ulid |= b[9];
+	ulid <<= 8;
+	ulid |= b[9];
 
-  ulid <<= 8;
-  ulid |= b[10];
+	ulid <<= 8;
+	ulid |= b[10];
 
-  ulid <<= 8;
-  ulid |= b[11];
+	ulid <<= 8;
+	ulid |= b[11];
 
-  ulid <<= 8;
-  ulid |= b[12];
+	ulid <<= 8;
+	ulid |= b[12];
 
-  ulid <<= 8;
-  ulid |= b[13];
+	ulid <<= 8;
+	ulid |= b[13];
 
-  ulid <<= 8;
-  ulid |= b[14];
+	ulid <<= 8;
+	ulid |= b[14];
 
-  ulid <<= 8;
-  ulid |= b[15];
+	ulid <<= 8;
+	ulid |= b[15];
 }
 
 /**
  * Unmarshal will create a new ULID by unmarshaling the passed byte vector.
  * */
 inline ULID UnmarshalBinary(const std::vector<uint8_t>& b) {
-  ULID ulid;
-  UnmarshalBinaryFrom(b.data(), ulid);
-  return ulid;
+	ULID ulid;
+	UnmarshalBinaryFrom(b.data(), ulid);
+	return ulid;
 }
 
 /**
@@ -540,33 +539,33 @@ inline ULID UnmarshalBinary(const std::vector<uint8_t>& b) {
  *      0 if ulid1 is same as ulid2
  * */
 inline int CompareULIDs(const ULID& ulid1, const ULID& ulid2) {
-  return -2 * (ulid1 < ulid2) - 1 * (ulid1 == ulid2) + 1;
+	return -2 * (ulid1 < ulid2) - 1 * (ulid1 == ulid2) + 1;
 }
 
 /**
  * Time will extract the timestamp used to generate a ULID
  * */
-inline time_t Time(const ULID& ulid) {
-  time_t ans = 0;
+inline std::chrono::time_point<std::chrono::system_clock> Time(const ULID& ulid) {
+	int64_t ans = 0;
 
-  ans |= static_cast<uint8_t>(ulid >> 120);
+	ans |= static_cast<uint8_t>(ulid >> 120);
 
-  ans <<= 8;
-  ans |= static_cast<uint8_t>(ulid >> 112);
+	ans <<= 8;
+	ans |= static_cast<uint8_t>(ulid >> 112);
 
-  ans <<= 8;
-  ans |= static_cast<uint8_t>(ulid >> 104);
+	ans <<= 8;
+	ans |= static_cast<uint8_t>(ulid >> 104);
 
-  ans <<= 8;
-  ans |= static_cast<uint8_t>(ulid >> 96);
+	ans <<= 8;
+	ans |= static_cast<uint8_t>(ulid >> 96);
 
-  ans <<= 8;
-  ans |= static_cast<uint8_t>(ulid >> 88);
+	ans <<= 8;
+	ans |= static_cast<uint8_t>(ulid >> 88);
 
-  ans <<= 8;
-  ans |= static_cast<uint8_t>(ulid >> 80);
+	ans <<= 8;
+	ans |= static_cast<uint8_t>(ulid >> 80);
 
-  return ans;
+	return std::chrono::time_point<std::chrono::system_clock>(std::chrono::milliseconds{ans});
 }
 
 };  // namespace ulid


### PR DESCRIPTION
This uses the [fork by Chris Bove](https://github.com/ChrisBove/ulid) which relies on `std::chrono` objects instead of `time_t` which permits the complete flowthrough of millisecond resolution.  The R wrapper was updated accordingly and an updated demo is now in the README.md